### PR TITLE
Throttle update to only occur one at a time

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,11 +64,13 @@ class App extends Component {
               scaleLean = scaleLinear().domain([0, this.svg.width/2, this.svg.width])
                                        .range([.5, 0, -.5]);
 
-        this.setState({
-            heightFactor: scaleFactor(y),
-            lean: scaleLean(x)
-        });
-        this.running = false;
+        this.setState(
+            {
+                heightFactor: scaleFactor(y),
+                lean: scaleLean(x)
+            },
+            () => this.running = false
+        );
     }
 
     render() {


### PR DESCRIPTION
By using the callback to `setState`, updates are only run one at a time once the
previous update has completely finished (ie; fully flushed to the DOM, which can take longer than it takes for the next `mousemove` event to fire).

Contrary to popular belief, `setState` is not necessarily synchronous.