### PR TITLE
[React 18] Add pending state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useTransition } from "react";
 import logo from "./logo.svg";
 import "./App.css";
 
@@ -20,6 +20,7 @@ function App() {
 
     const [treeLeanInput, setTreeLeanInput] = useState(0);
     const [treeLean, setTreeLean] = useState(0);
+    const [isLeaning, startLeaning] = useTransition()
 
     const [enableStartTransition, setEnableStartTransition] = useState(false);
 
@@ -43,7 +44,7 @@ function App() {
 
         // update visuals
         if (enableStartTransition) {
-            React.startTransition(() => {
+            startLeaning(() => {
                 setTreeLean(value);
             });
         } else {
@@ -119,7 +120,10 @@ function App() {
                 <svg
                     width={svg.width}
                     height={svg.height}
-                    style={{ border: "1px solid lightgray" }}
+                    className={isLeaning ? 'pending' : 'done'}
+                    style={{
+                        border: "1px solid lightgray",
+                    }}
                 >
                     <Pythagoras
                         w={baseWidth}

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,12 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+.pending {
+  opacity: 0.7;
+  transition: opacity 0.2s 0.4s linear;
+}
+.done {
+  opacity: 1;
+  transition: opacity 0 0 linear;
+}


### PR DESCRIPTION
On fast computers, the pending state isn't usually shown (due to delay).

If you make the tree deep or slow down your computer with throttling, you'll see the tree's opacity change during long transitions.