### PR TITLE
[React 18] Add slow mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ function App() {
     const [treeLean, setTreeLean] = useState(0);
 
     const [enableStartTransition, setEnableStartTransition] = useState(false);
+    const [enableSlowdown, setEnableSlowdown] = useState(false);
 
     function changeTreeSize(event) {
         const value = Number(event.target.value);
@@ -53,6 +54,10 @@ function App() {
 
     function toggleStartTransition() {
         setEnableStartTransition(!enableStartTransition);
+    }
+
+    function toggleSlowdown(event) {
+        setEnableSlowdown(event.target.checked);
     }
 
     return (
@@ -91,6 +96,15 @@ function App() {
                         style={{ width: svg.width / 3 }}
                     />
                 </div>
+                <div>
+                    <label>Make each square block the thread for 0.1ms</label>
+                    <br />
+                    <input
+                        type="checkbox"
+                        checked={enableSlowdown}
+                        onChange={toggleSlowdown}
+                    />
+                </div>
             </div>
 
             <div style={{ display: "flex", flexDirection: "row" }}>
@@ -122,6 +136,7 @@ function App() {
                     style={{ border: "1px solid lightgray" }}
                 >
                     <Pythagoras
+                        enableSlowdown={enableSlowdown}
                         w={baseWidth}
                         h={baseWidth}
                         heightFactor={heightFactor}

--- a/src/Pythagoras.js
+++ b/src/Pythagoras.js
@@ -44,9 +44,17 @@ const Pythagoras = React.memo(({
     right,
     lvl,
     maxlvl,
+    enableSlowdown,
 }) => {
     if (lvl >= maxlvl || w < 1) {
         return null;
+    }
+
+    if (enableSlowdown) {
+        let now = performance.now();
+        while (performance.now() - now < 0.1) {
+            // do nothing
+        }
     }
 
     const { nextRight, nextLeft, A, B } = memoizedCalc({
@@ -74,6 +82,7 @@ const Pythagoras = React.memo(({
             />
 
             <Pythagoras
+                enableSlowdown={enableSlowdown}
                 w={nextLeft}
                 x={0}
                 y={-nextLeft}
@@ -85,6 +94,7 @@ const Pythagoras = React.memo(({
             />
 
             <Pythagoras
+                enableSlowdown={enableSlowdown}
                 w={nextRight}
                 x={w - nextRight}
                 y={-nextRight}


### PR DESCRIPTION
This is an essential part that most comparisons and ports to other libraries tend to miss.

Of course, React is not the most efficient way to render a viz like this. You're better off with GL. But this particular example I'm adding has a neat aspect.

When the checkbox is ticked, each square is forced to spend 0.1ms blocking the thread. This simulates "death by a thousand cuts" where you have a large update that needs to run a bunch of **user-written code**. There's just no way you can "optimize it away". What's interesting is how the system handles a bunch of computational work distributed between a tree of components.

Compare the behavior with startTransition vs without it.

[Demo link](https://react-fractals-git-fork-gaearon-both-swizec.vercel.app/)

Tick this checkbox:

<img width="403" alt="Screenshot 2021-06-16 at 02 21 39" src="https://user-images.githubusercontent.com/810438/122143563-9c96e000-ce49-11eb-83a3-88984288b1aa.png">

**The effect is pronounced after you increase the tree size with the slider on the left.**